### PR TITLE
Add `setuptools_scm` to properly report the version

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpythonpython_implcpython.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -21,7 +17,5 @@ python_impl:
 target_platform:
 - linux-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - python_impl

--- a/.ci_support/linux_64_python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpythonpython_implcpython.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -21,7 +17,5 @@ python_impl:
 target_platform:
 - linux-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - python_impl

--- a/.ci_support/linux_64_python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpythonpython_implcpython.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -21,7 +17,5 @@ python_impl:
 target_platform:
 - linux-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - python_impl

--- a/.ci_support/linux_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonpython_implcpython.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -21,7 +17,5 @@ python_impl:
 target_platform:
 - linux-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - python_impl

--- a/.ci_support/linux_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonpython_implcpython.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -21,7 +17,5 @@ python_impl:
 target_platform:
 - linux-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - python_impl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [python_impl == 'pypy']
   skip: true  # [py<38 or win or osx]
@@ -20,6 +20,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools_scm
   run:
     - python
     - apischema


### PR DESCRIPTION
Currently, the reported version of the `hklpy` package is 0.0.0:

```bash
$ conda list | grep hkl
# packages in environment at .../hklpy311:
hkl                       5.0.0.3434      py311h38be061_0    conda-forge
hklpy                     0.0.0                    pypi_0    pypi
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
